### PR TITLE
Adding osu, pytorch, mpi4py results for Lustre

### DIFF
--- a/data/lustre-baseline/osu/slurm-4142496.out
+++ b/data/lustre-baseline/osu/slurm-4142496.out
@@ -1,0 +1,82 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 99 ms, max: 108 ms, avg: 103 ms
+0.01user 0.03system 0:01.14elapsed 4%CPU (0avgtext+0avgdata 17408maxresident)k
+2928inputs+0outputs (10major+3211minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 11 ms, max: 22 ms, avg: 16 ms
+0.01user 0.01system 0:00.30elapsed 8%CPU (0avgtext+0avgdata 17408maxresident)k
+38inputs+0outputs (0major+3215minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 14 ms, max: 18 ms, avg: 16 ms
+0.01user 0.01system 0:00.30elapsed 8%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3215minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 15 ms, max: 25 ms, avg: 18 ms
+0.01user 0.01system 0:00.29elapsed 8%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3215minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 9 ms, max: 23 ms, avg: 16 ms
+0.01user 0.01system 0:00.31elapsed 8%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3215minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4142570.out
+++ b/data/lustre-baseline/osu/slurm-4142570.out
@@ -1,0 +1,85 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 420 ms, max: 778 ms, avg: 528 ms
+0.02user 0.02system 0:01.88elapsed 2%CPU (0avgtext+0avgdata 18432maxresident)k
+2766inputs+0outputs (10major+3399minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4142570.1
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 733 ms, max: 775 ms, avg: 755 ms
+0.01user 0.02system 0:01.10elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3403minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4142570.2
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 718 ms, max: 764 ms, avg: 738 ms
+0.01user 0.02system 0:01.16elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3404minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4142570.3
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 713 ms, max: 762 ms, avg: 741 ms
+0.01user 0.02system 0:01.08elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3403minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 255 ms, max: 301 ms, avg: 278 ms
+0.01user 0.02system 0:00.61elapsed 5%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3403minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4142571.out
+++ b/data/lustre-baseline/osu/slurm-4142571.out
@@ -1,0 +1,86 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 2404 ms, max: 3492 ms, avg: 3130 ms
+0.01user 0.07system 0:05.01elapsed 1%CPU (0avgtext+0avgdata 18432maxresident)k
+2766inputs+0outputs (10major+3926minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4142571.1
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 633 ms, max: 792 ms, avg: 766 ms
+0.01user 0.04system 0:01.16elapsed 5%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3930minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4142571.2
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 628 ms, max: 794 ms, avg: 761 ms
+0.01user 0.04system 0:01.25elapsed 4%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3930minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4142571.3
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 729 ms, max: 804 ms, avg: 767 ms
+0.01user 0.04system 0:01.26elapsed 4%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3930minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4142571.4
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 667 ms, max: 801 ms, avg: 772 ms
+0.01user 0.05system 0:01.25elapsed 5%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3931minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4142573.out
+++ b/data/lustre-baseline/osu/slurm-4142573.out
@@ -1,0 +1,85 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 964 ms, max: 1747 ms, avg: 1353 ms
+0.08user 0.20system 0:08.08elapsed 3%CPU (0avgtext+0avgdata 21504maxresident)k
+2788inputs+0outputs (10major+6041minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4142573.1
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 589 ms, max: 843 ms, avg: 791 ms
+0.07user 0.16system 0:06.44elapsed 3%CPU (0avgtext+0avgdata 19456maxresident)k
+38inputs+0outputs (0major+6049minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4142573.2
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 652 ms, max: 826 ms, avg: 796 ms
+0.06user 0.16system 0:06.35elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+6047minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4142573.3
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 679 ms, max: 858 ms, avg: 826 ms
+0.06user 0.16system 0:06.42elapsed 3%CPU (0avgtext+0avgdata 20480maxresident)k
+0inputs+0outputs (0major+6047minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 639 ms, max: 821 ms, avg: 788 ms
+0.07user 0.16system 0:07.77elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+6047minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4142574.out
+++ b/data/lustre-baseline/osu/slurm-4142574.out
@@ -1,0 +1,85 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 2757 ms, max: 4435 ms, avg: 3709 ms
+0.15user 0.35system 0:11.25elapsed 4%CPU (0avgtext+0avgdata 28672maxresident)k
+2788inputs+0outputs (10major+6988minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4142574.1
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 673 ms, max: 943 ms, avg: 848 ms
+0.11user 0.29system 1:40.89elapsed 0%CPU (0avgtext+0avgdata 23552maxresident)k
+38inputs+8outputs (0major+7533minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 784 ms, max: 949 ms, avg: 856 ms
+0.11user 0.30system 0:06.66elapsed 6%CPU (0avgtext+0avgdata 24576maxresident)k
+0inputs+0outputs (0major+7533minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Job 4142574 step creation temporarily disabled, retrying (Requested nodes are busy)
+srun: Step created for StepId=4142574.3
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 692 ms, max: 866 ms, avg: 824 ms
+0.11user 0.30system 2:12.59elapsed 0%CPU (0avgtext+0avgdata 22528maxresident)k
+0inputs+8outputs (0major+7534minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 680 ms, max: 860 ms, avg: 814 ms
+0.11user 0.29system 0:07.46elapsed 5%CPU (0avgtext+0avgdata 24576maxresident)k
+0inputs+0outputs (0major+7533minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4145715.out
+++ b/data/lustre-baseline/osu/slurm-4145715.out
@@ -1,0 +1,82 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 105 ms, max: 114 ms, avg: 109 ms
+0.01user 0.02system 0:01.23elapsed 3%CPU (0avgtext+0avgdata 17408maxresident)k
+2788inputs+0outputs (10major+3211minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 9 ms, max: 32 ms, avg: 22 ms
+0.01user 0.01system 0:00.32elapsed 8%CPU (0avgtext+0avgdata 17408maxresident)k
+38inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 11 ms, max: 29 ms, avg: 21 ms
+0.01user 0.01system 0:00.46elapsed 6%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 9 ms, max: 33 ms, avg: 22 ms
+0.01user 0.01system 0:00.30elapsed 8%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 7 ms, max: 247 ms, avg: 153 ms
+0.01user 0.01system 0:00.52elapsed 4%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4145717.out
+++ b/data/lustre-baseline/osu/slurm-4145717.out
@@ -1,0 +1,86 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 413 ms, max: 832 ms, avg: 528 ms
+0.01user 0.03system 0:01.97elapsed 2%CPU (0avgtext+0avgdata 17408maxresident)k
+2788inputs+0outputs (10major+3398minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145717.1
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 253 ms, max: 287 ms, avg: 272 ms
+0.01user 0.02system 0:00.61elapsed 5%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3403minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145717.2
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 251 ms, max: 296 ms, avg: 274 ms
+0.01user 0.02system 0:00.60elapsed 5%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3403minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145717.3
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 249 ms, max: 304 ms, avg: 270 ms
+0.01user 0.02system 0:00.59elapsed 5%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3404minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145717.4
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 741 ms, max: 783 ms, avg: 761 ms
+0.01user 0.02system 0:01.11elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3403minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4145720.out
+++ b/data/lustre-baseline/osu/slurm-4145720.out
@@ -1,0 +1,86 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 744 ms, max: 1339 ms, avg: 1008 ms
+0.01user 0.07system 0:02.49elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+2788inputs+0outputs (10major+3925minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145720.1
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 625 ms, max: 793 ms, avg: 762 ms
+0.02user 0.03system 0:01.21elapsed 5%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3930minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145720.2
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 746 ms, max: 796 ms, avg: 768 ms
+0.03user 0.02system 0:01.25elapsed 5%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3929minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145720.3
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 525 ms, max: 800 ms, avg: 770 ms
+0.01user 0.04system 0:01.26elapsed 4%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3930minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145720.4
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 743 ms, max: 792 ms, avg: 764 ms
+0.01user 0.05system 0:01.26elapsed 5%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3929minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4145721.out
+++ b/data/lustre-baseline/osu/slurm-4145721.out
@@ -1,0 +1,85 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 671 ms, max: 1736 ms, avg: 1482 ms
+0.08user 0.22system 0:08.77elapsed 3%CPU (0avgtext+0avgdata 20480maxresident)k
+2766inputs+0outputs (10major+5275minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145721.1
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 680 ms, max: 853 ms, avg: 791 ms
+0.06user 0.17system 0:06.40elapsed 3%CPU (0avgtext+0avgdata 21504maxresident)k
+38inputs+0outputs (0major+5281minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145721.2
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 675 ms, max: 837 ms, avg: 800 ms
+0.06user 0.16system 0:06.34elapsed 3%CPU (0avgtext+0avgdata 21504maxresident)k
+38inputs+0outputs (0major+5279minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145721.3
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 658 ms, max: 823 ms, avg: 791 ms
+0.06user 0.16system 0:06.34elapsed 3%CPU (0avgtext+0avgdata 19456maxresident)k
+38inputs+0outputs (0major+5281minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 637 ms, max: 822 ms, avg: 789 ms
+0.06user 0.16system 0:08.01elapsed 2%CPU (0avgtext+0avgdata 21504maxresident)k
+0inputs+8outputs (0major+5281minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4145722.out
+++ b/data/lustre-baseline/osu/slurm-4145722.out
@@ -1,0 +1,85 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 2785 ms, max: 4279 ms, avg: 3785 ms
+0.17user 0.36system 0:11.29elapsed 4%CPU (0avgtext+0avgdata 21504maxresident)k
+2788inputs+0outputs (10major+6726minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145722.1
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 747 ms, max: 922 ms, avg: 831 ms
+0.12user 0.30system 0:06.82elapsed 6%CPU (0avgtext+0avgdata 24576maxresident)k
+38inputs+0outputs (0major+6731minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145722.2
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 679 ms, max: 843 ms, avg: 804 ms
+0.11user 0.30system 0:06.61elapsed 6%CPU (0avgtext+0avgdata 21504maxresident)k
+0inputs+0outputs (0major+6732minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145722.3
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 674 ms, max: 843 ms, avg: 801 ms
+0.12user 0.28system 0:06.52elapsed 6%CPU (0avgtext+0avgdata 24576maxresident)k
+0inputs+0outputs (0major+6732minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 678 ms, max: 872 ms, avg: 802 ms
+0.12user 0.29system 0:06.88elapsed 6%CPU (0avgtext+0avgdata 23552maxresident)k
+0inputs+8outputs (0major+6731minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4145723.out
+++ b/data/lustre-baseline/osu/slurm-4145723.out
@@ -1,0 +1,82 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 159 ms, max: 159 ms, avg: 159 ms
+0.01user 0.02system 0:01.17elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+2788inputs+0outputs (10major+3211minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 11 ms, max: 18 ms, avg: 14 ms
+0.01user 0.01system 0:00.30elapsed 8%CPU (0avgtext+0avgdata 17408maxresident)k
+38inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 10 ms, max: 21 ms, avg: 14 ms
+0.01user 0.01system 0:00.30elapsed 9%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 8 ms, max: 19 ms, avg: 14 ms
+0.01user 0.01system 0:00.28elapsed 9%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8, min: 7 ms, max: 22 ms, avg: 14 ms
+0.01user 0.01system 0:00.31elapsed 8%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4145724.out
+++ b/data/lustre-baseline/osu/slurm-4145724.out
@@ -1,0 +1,86 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 404 ms, max: 964 ms, avg: 624 ms
+0.01user 0.04system 0:02.06elapsed 2%CPU (0avgtext+0avgdata 17408maxresident)k
+2788inputs+0outputs (10major+3402minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145724.1
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 250 ms, max: 282 ms, avg: 263 ms
+0.01user 0.02system 0:00.72elapsed 4%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3406minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145724.2
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 250 ms, max: 279 ms, avg: 262 ms
+0.00user 0.02system 0:00.60elapsed 5%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3405minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145724.3
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 248 ms, max: 283 ms, avg: 261 ms
+0.01user 0.02system 0:00.59elapsed 5%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3405minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145724.4
+# OSU MPI Init Test v7.5
+nprocs: 64, min: 249 ms, max: 297 ms, avg: 270 ms
+0.01user 0.02system 0:00.60elapsed 5%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3405minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4145725.out
+++ b/data/lustre-baseline/osu/slurm-4145725.out
@@ -1,0 +1,86 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 788 ms, max: 1441 ms, avg: 1002 ms
+0.01user 0.07system 0:02.74elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+2788inputs+0outputs (10major+3924minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145725.1
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 745 ms, max: 795 ms, avg: 770 ms
+0.01user 0.04system 0:01.26elapsed 4%CPU (0avgtext+0avgdata 17408maxresident)k
+38inputs+0outputs (0major+3928minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145725.2
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 743 ms, max: 799 ms, avg: 768 ms
+0.01user 0.04system 0:01.26elapsed 5%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3928minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145725.3
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 664 ms, max: 806 ms, avg: 766 ms
+0.01user 0.04system 0:01.25elapsed 4%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3929minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145725.4
+# OSU MPI Init Test v7.5
+nprocs: 512, min: 526 ms, max: 802 ms, avg: 767 ms
+0.01user 0.04system 0:01.16elapsed 5%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3929minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4145726.out
+++ b/data/lustre-baseline/osu/slurm-4145726.out
@@ -1,0 +1,85 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 1149 ms, max: 1874 ms, avg: 1658 ms
+0.11user 0.16system 0:08.38elapsed 3%CPU (0avgtext+0avgdata 21504maxresident)k
+2792inputs+0outputs (10major+5278minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145726.1
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 636 ms, max: 835 ms, avg: 797 ms
+0.11user 0.12system 0:06.39elapsed 3%CPU (0avgtext+0avgdata 19456maxresident)k
+38inputs+0outputs (0major+5282minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145726.2
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 645 ms, max: 828 ms, avg: 792 ms
+0.10user 0.13system 0:06.34elapsed 3%CPU (0avgtext+0avgdata 19456maxresident)k
+0inputs+0outputs (0major+5281minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145726.3
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 635 ms, max: 817 ms, avg: 781 ms
+0.06user 0.16system 0:06.32elapsed 3%CPU (0avgtext+0avgdata 19456maxresident)k
+0inputs+0outputs (0major+5283minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 4096, min: 650 ms, max: 819 ms, avg: 787 ms
+0.10user 0.12system 0:07.99elapsed 2%CPU (0avgtext+0avgdata 19456maxresident)k
+0inputs+8outputs (0major+5283minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/osu/slurm-4145727.out
+++ b/data/lustre-baseline/osu/slurm-4145727.out
@@ -1,0 +1,85 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
++ ldd /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+	linux-vdso.so.1 (0x00007fffed9ce000)
+	libamdhip64.so.6 => /opt/rocm-6.4.2/lib/libamdhip64.so.6 (0x00007fffec1ed000)
+	libm.so.6 => /lib64/libm.so.6 (0x00007fffec0ed000)
+	libdarshan.so.0 => /sw/frontier/spack-envs/cpe25.09-cpu/opt/llvm-amdgpu-6.4.2/darshan-runtime-3.4.7-tvdocpzv3jfj4y6ki5jvmmkics323gon/lib/libdarshan.so.0 (0x00007fffec09e000)
+	libz.so.1 => /usr/lib64/libz.so.1 (0x00007fffec085000)
+	libmpi_amd.so.12 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_amd.so.12 (0x00007fffeaf35000)
+	libmpi_gtl_hsa.so.0 => /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0/lib/libmpi_gtl_hsa.so.0 (0x00007fffeae8a000)
+	libxpmem.so.0 => /usr/lib64/libxpmem.so.0 (0x00007fffeae87000)
+	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffeac31000)
+	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffeac04000)
+	libc.so.6 => /lib64/libc.so.6 (0x00007fffea9ef000)
+	librocprofiler-register.so.0 => /opt/rocm-6.4.2/lib/librocprofiler-register.so.0 (0x00007fffea96e000)
+	libamd_comgr.so.3 => /opt/rocm-6.4.2/lib/libamd_comgr.so.3 (0x00007fffe11c1000)
+	libhsa-runtime64.so.1 => /opt/rocm-6.4.2/lib/libhsa-runtime64.so.1 (0x00007fffe0e77000)
+	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe0c00000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fffed9d0000)
+	libfabric.so.1 => /opt/cray/libfabric/1.22.0/lib64/libfabric.so.1 (0x00007fffe0ac9000)
+	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffe0e6b000)
+	libpmi.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi.so.0 (0x00007fffe0e47000)
+	libpmi2.so.0 => /opt/cray/pe/pmi/6.1.16/lib/libpmi2.so.0 (0x00007fffe0e23000)
+	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007fffe0a0a000)
+	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffe0600000)
+	libdrm.so.2 => /opt/amdgpu/lib64/libdrm.so.2 (0x00007fffe09f3000)
+	libdrm_amdgpu.so.1 => /opt/amdgpu/lib64/libdrm_amdgpu.so.1 (0x00007fffe0e13000)
+	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffe09d2000)
+	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffe0e0e000)
+	libpals.so.0 => /opt/cray/pals/1.6/lib/libpals.so.0 (0x00007fffe09ca000)
+	libnl-3.so.200 => /usr/lib64/libnl-3.so.200 (0x00007fffe09a7000)
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 2218 ms, max: 3786 ms, avg: 3308 ms
+0.17user 0.36system 0:10.52elapsed 5%CPU (0avgtext+0avgdata 23552maxresident)k
+2788inputs+0outputs (10major+6727minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145727.1
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 665 ms, max: 882 ms, avg: 802 ms
+0.11user 0.29system 0:06.56elapsed 6%CPU (0avgtext+0avgdata 25600maxresident)k
+38inputs+0outputs (0major+6731minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145727.2
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 683 ms, max: 847 ms, avg: 807 ms
+0.11user 0.30system 0:06.56elapsed 6%CPU (0avgtext+0avgdata 24576maxresident)k
+0inputs+0outputs (0major+6731minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+srun: Step created for StepId=4145727.3
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 693 ms, max: 872 ms, avg: 817 ms
+0.11user 0.29system 0:06.54elapsed 6%CPU (0avgtext+0avgdata 24576maxresident)k
+0inputs+0outputs (0major+6731minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest /lustre/orion/stf243/world-shared/hagertnl/CUG26/benchmark_builds/osu/install-osu-7.5.1/libexec/osu-micro-benchmarks/mpi/startup/osu_init
+# OSU MPI Init Test v7.5
+nprocs: 8192, min: 630 ms, max: 844 ms, avg: 804 ms
+0.12user 0.28system 0:08.02elapsed 5%CPU (0avgtext+0avgdata 23552maxresident)k
+0inputs+0outputs (0major+6731minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4142594.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4142594.out
@@ -1,0 +1,43 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.02system 0:01.48elapsed 2%CPU (0avgtext+0avgdata 17408maxresident)k
+2624inputs+0outputs (8major+3214minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.01system 0:00.32elapsed 9%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3217minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.01system 0:00.34elapsed 8%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3217minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.01system 0:00.32elapsed 8%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3217minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.01system 0:00.31elapsed 9%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3217minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4142596.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4142596.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.02user 0.03system 0:01.82elapsed 3%CPU (0avgtext+0avgdata 17408maxresident)k
+2854inputs+0outputs (10major+3399minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142596.1
+0.01user 0.02system 0:01.09elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3405minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142596.2
+0.01user 0.02system 0:00.75elapsed 4%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3405minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142596.3
+0.01user 0.02system 0:00.63elapsed 5%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3405minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142596.4
+0.01user 0.02system 0:01.12elapsed 3%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3405minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4142597.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4142597.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.07system 0:05.09elapsed 1%CPU (0avgtext+0avgdata 18432maxresident)k
+2854inputs+0outputs (10major+3924minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142597.1
+0.01user 0.04system 0:01.29elapsed 4%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3928minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142597.2
+0.01user 0.04system 0:01.19elapsed 5%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3928minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142597.3
+0.01user 0.04system 0:01.28elapsed 4%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3927minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142597.4
+0.01user 0.04system 0:01.18elapsed 4%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3928minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4142598.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4142598.out
@@ -1,0 +1,46 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.08user 0.20system 0:10.81elapsed 2%CPU (0avgtext+0avgdata 23552maxresident)k
+2864inputs+0outputs (10major+5898minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142598.1
+0.07user 0.17system 0:06.64elapsed 3%CPU (0avgtext+0avgdata 20480maxresident)k
+38inputs+0outputs (0major+5904minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142598.2
+0.07user 0.17system 0:06.45elapsed 3%CPU (0avgtext+0avgdata 19456maxresident)k
+0inputs+0outputs (0major+5903minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.07user 0.17system 0:07.52elapsed 3%CPU (0avgtext+0avgdata 20480maxresident)k
+0inputs+0outputs (0major+5904minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142598.4
+0.07user 0.17system 0:06.46elapsed 3%CPU (0avgtext+0avgdata 19456maxresident)k
+0inputs+0outputs (0major+5904minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4142599.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4142599.out
@@ -1,0 +1,46 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.15user 0.35system 0:12.27elapsed 4%CPU (0avgtext+0avgdata 26624maxresident)k
+2854inputs+0outputs (10major+6741minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142599.1
+0.15user 0.25system 0:07.33elapsed 5%CPU (0avgtext+0avgdata 21504maxresident)k
+38inputs+0outputs (0major+7294minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142599.2
+0.17user 0.25system 0:06.77elapsed 6%CPU (0avgtext+0avgdata 22528maxresident)k
+0inputs+0outputs (0major+7294minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.18user 0.26system 0:07.81elapsed 5%CPU (0avgtext+0avgdata 21504maxresident)k
+0inputs+0outputs (0major+7298minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4142599.4
+0.17user 0.25system 0:06.56elapsed 6%CPU (0avgtext+0avgdata 23552maxresident)k
+0inputs+0outputs (0major+7293minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4145742.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4145742.out
@@ -1,0 +1,43 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.03system 0:01.41elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+2854inputs+0outputs (10major+3211minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.01system 0:00.32elapsed 8%CPU (0avgtext+0avgdata 17408maxresident)k
+38inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.01system 0:00.34elapsed 8%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.01system 0:00.32elapsed 9%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.01system 0:00.34elapsed 8%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4145743.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4145743.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.03system 0:02.01elapsed 2%CPU (0avgtext+0avgdata 18432maxresident)k
+2854inputs+0outputs (10major+3402minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145743.1
+0.01user 0.02system 0:00.76elapsed 4%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3407minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145743.2
+0.00user 0.02system 0:00.62elapsed 4%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3407minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145743.3
+0.01user 0.02system 0:01.11elapsed 3%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3407minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145743.4
+0.01user 0.02system 0:01.10elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3407minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4145745.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4145745.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.04user 0.04system 0:03.69elapsed 2%CPU (0avgtext+0avgdata 18432maxresident)k
+2864inputs+0outputs (10major+3919minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145745.1
+0.03user 0.02system 0:01.56elapsed 3%CPU (0avgtext+0avgdata 17408maxresident)k
+38inputs+0outputs (0major+3927minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145745.2
+0.01user 0.04system 0:01.52elapsed 4%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3927minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145745.3
+0.01user 0.04system 0:01.50elapsed 4%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3927minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145745.4
+0.03user 0.02system 0:01.50elapsed 3%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3927minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4145746.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4145746.out
@@ -1,0 +1,49 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.10user 0.22system 0:12.66elapsed 2%CPU (0avgtext+0avgdata 19456maxresident)k
+3016inputs+0outputs (10major+5119minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Job 4145746 step creation temporarily disabled, retrying (Requested nodes are busy)
+srun: Step created for StepId=4145746.1
+0.07user 0.18system 2:07.80elapsed 0%CPU (0avgtext+0avgdata 19456maxresident)k
+38inputs+8outputs (0major+5125minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145746.2
+0.06user 0.18system 0:32.56elapsed 0%CPU (0avgtext+0avgdata 19456maxresident)k
+0inputs+8outputs (0major+5123minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Job 4145746 step creation temporarily disabled, retrying (Requested nodes are busy)
+srun: Step created for StepId=4145746.3
+0.07user 0.17system 2:12.82elapsed 0%CPU (0avgtext+0avgdata 19456maxresident)k
+0inputs+8outputs (0major+5125minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145746.4
+0.06user 0.18system 0:44.02elapsed 0%CPU (0avgtext+0avgdata 19456maxresident)k
+0inputs+8outputs (0major+5123minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4145747.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4145747.out
@@ -1,0 +1,46 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.17user 0.38system 0:13.00elapsed 4%CPU (0avgtext+0avgdata 20480maxresident)k
+2854inputs+0outputs (10major+6417minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145747.1
+0.12user 0.28system 0:07.43elapsed 5%CPU (0avgtext+0avgdata 23552maxresident)k
+38inputs+0outputs (0major+6422minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145747.2
+0.12user 0.28system 0:06.70elapsed 6%CPU (0avgtext+0avgdata 22528maxresident)k
+0inputs+0outputs (0major+6422minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.12user 0.29system 0:07.65elapsed 5%CPU (0avgtext+0avgdata 22528maxresident)k
+0inputs+0outputs (0major+6422minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145747.4
+0.12user 0.29system 0:06.58elapsed 6%CPU (0avgtext+0avgdata 22528maxresident)k
+0inputs+0outputs (0major+6422minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4145748.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4145748.out
@@ -1,0 +1,43 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.03system 0:01.39elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+2854inputs+0outputs (10major+3211minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.01system 0:00.32elapsed 8%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.01system 0:00.33elapsed 8%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.01system 0:00.33elapsed 8%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.01system 0:00.34elapsed 7%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3216minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4145749.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4145749.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.01user 0.04system 0:02.62elapsed 2%CPU (0avgtext+0avgdata 17408maxresident)k
+3026inputs+0outputs (10major+3403minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145749.1
+0.01user 0.02system 0:01.20elapsed 2%CPU (0avgtext+0avgdata 16384maxresident)k
+38inputs+0outputs (0major+3407minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145749.2
+0.01user 0.01system 0:01.20elapsed 2%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3407minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145749.3
+0.01user 0.02system 0:01.11elapsed 3%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3407minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145749.4
+0.01user 0.02system 0:01.10elapsed 3%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3407minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4145750.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4145750.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.02user 0.07system 0:05.04elapsed 1%CPU (0avgtext+0avgdata 18432maxresident)k
+2864inputs+0outputs (10major+3923minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145750.1
+0.01user 0.04system 0:01.45elapsed 4%CPU (0avgtext+0avgdata 17408maxresident)k
+38inputs+0outputs (0major+3927minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145750.2
+0.02user 0.04system 0:01.40elapsed 4%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3927minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145750.3
+0.01user 0.04system 0:01.48elapsed 4%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3928minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145750.4
+0.01user 0.04system 0:01.42elapsed 4%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3927minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4145751.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4145751.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.09user 0.23system 0:16.43elapsed 1%CPU (0avgtext+0avgdata 20480maxresident)k
+2854inputs+0outputs (10major+5095minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145751.1
+0.06user 0.18system 0:06.66elapsed 3%CPU (0avgtext+0avgdata 19456maxresident)k
+38inputs+0outputs (0major+5097minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145751.2
+0.06user 0.18system 0:06.35elapsed 3%CPU (0avgtext+0avgdata 20480maxresident)k
+0inputs+0outputs (0major+5097minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145751.3
+0.06user 0.17system 0:06.88elapsed 3%CPU (0avgtext+0avgdata 19456maxresident)k
+0inputs+0outputs (0major+5098minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145751.4
+0.06user 0.18system 0:06.32elapsed 3%CPU (0avgtext+0avgdata 20480maxresident)k
+0inputs+0outputs (0major+5098minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-mpi4py/slurm-4145752.out
+++ b/data/lustre-baseline/python-mpi4py/slurm-4145752.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+0.18user 0.38system 0:12.21elapsed 4%CPU (0avgtext+0avgdata 23552maxresident)k
+2864inputs+0outputs (10major+6417minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145752.1
+0.10user 0.28system 0:06.54elapsed 6%CPU (0avgtext+0avgdata 22528maxresident)k
+38inputs+0outputs (0major+6422minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145752.2
+0.12user 0.28system 0:06.62elapsed 6%CPU (0avgtext+0avgdata 22528maxresident)k
+38inputs+0outputs (0major+6422minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145752.3
+0.11user 0.29system 0:06.55elapsed 6%CPU (0avgtext+0avgdata 21504maxresident)k
+0inputs+0outputs (0major+6422minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'from mpi4py import MPI'
+srun: Step created for StepId=4145752.4
+0.12user 0.28system 0:06.57elapsed 6%CPU (0avgtext+0avgdata 21504maxresident)k
+0inputs+0outputs (0major+6422minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4142588.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4142588.out
@@ -1,0 +1,43 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.03system 0:28.18elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+2624inputs+0outputs (8major+3214minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.01system 0:11.32elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+38inputs+0outputs (0major+3218minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.01system 0:11.36elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3217minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.01system 0:11.34elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3217minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.01system 0:11.33elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3218minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4142589.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4142589.out
@@ -1,0 +1,45 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.03system 0:22.85elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+2854inputs+0outputs (10major+3399minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4142589.1
+0.01user 0.02system 0:11.50elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+38inputs+0outputs (0major+3404minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4142589.2
+0.01user 0.02system 0:11.44elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3404minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.02user 0.01system 0:11.60elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3404minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.02user 0.01system 0:12.20elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3404minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4142590.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4142590.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.02user 0.07system 0:18.88elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+2854inputs+0outputs (10major+3921minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4142590.1
+0.04user 0.03system 0:12.26elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3929minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4142590.2
+0.01user 0.06system 0:12.58elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3928minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4142590.3
+0.01user 0.06system 0:12.26elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3927minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4142590.4
+0.02user 0.06system 0:12.28elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3929minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4142592.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4142592.out
@@ -1,0 +1,50 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.32user 0.61system 1:02.85elapsed 1%CPU (0avgtext+0avgdata 21504maxresident)k
+2864inputs+0outputs (10major+5121minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4142592.1
+0.26user 0.66system 2:36.43elapsed 0%CPU (0avgtext+0avgdata 19456maxresident)k
+38inputs+8outputs (0major+5124minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Job 4142592 step creation temporarily disabled, retrying (Requested nodes are busy)
+srun: Step created for StepId=4142592.2
+0.23user 0.61system 2:41.29elapsed 0%CPU (0avgtext+0avgdata 20480maxresident)k
+38inputs+8outputs (0major+5126minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Job 4142592 step creation temporarily disabled, retrying (Requested nodes are busy)
+srun: Step created for StepId=4142592.3
+0.28user 0.69system 2:43.88elapsed 0%CPU (0avgtext+0avgdata 20480maxresident)k
+0inputs+8outputs (0major+5124minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Job 4142592 step creation temporarily disabled, retrying (Requested nodes are busy)
+srun: Step created for StepId=4142592.4
+0.23user 0.63system 2:46.34elapsed 0%CPU (0avgtext+0avgdata 20480maxresident)k
+0inputs+8outputs (0major+5124minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4142593.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4142593.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.92user 1.87system 1:45.36elapsed 2%CPU (0avgtext+0avgdata 23552maxresident)k
+3016inputs+0outputs (10major+6764minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4142593.1
+0.73user 1.90system 2:10.92elapsed 2%CPU (0avgtext+0avgdata 23552maxresident)k
+38inputs+8outputs (0major+7294minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4142593.2
+0.77user 1.95system 0:59.97elapsed 4%CPU (0avgtext+0avgdata 22528maxresident)k
+0inputs+0outputs (0major+7297minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4142593.3
+0.79user 1.97system 1:04.29elapsed 4%CPU (0avgtext+0avgdata 22528maxresident)k
+0inputs+0outputs (0major+7294minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4142593.4
+0.76user 1.97system 0:59.91elapsed 4%CPU (0avgtext+0avgdata 23552maxresident)k
+0inputs+0outputs (0major+7294minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4145730.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4145730.out
@@ -1,0 +1,43 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.03system 0:25.11elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+2854inputs+0outputs (10major+3212minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.01system 0:11.44elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3217minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.01system 0:11.75elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3217minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.01system 0:11.41elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3217minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.01system 0:11.87elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3217minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4145732.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4145732.out
@@ -1,0 +1,44 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.04system 0:26.01elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+2854inputs+0outputs (10major+3400minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.00user 0.02system 0:11.50elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3406minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.02system 0:11.83elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3406minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.02system 0:11.40elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3406minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145732.4
+0.00user 0.02system 0:11.99elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3407minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4145733.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4145733.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.02user 0.08system 0:24.07elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+2854inputs+0outputs (10major+3922minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145733.1
+0.01user 0.06system 0:14.65elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+38inputs+0outputs (0major+3928minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145733.2
+0.02user 0.06system 0:14.45elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3927minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145733.3
+0.02user 0.06system 0:14.22elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3928minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145733.4
+0.04user 0.04system 0:14.70elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3928minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4145734.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4145734.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.26user 0.64system 1:03.79elapsed 1%CPU (0avgtext+0avgdata 20480maxresident)k
+2854inputs+0outputs (10major+5147minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145734.1
+0.24user 0.68system 0:37.99elapsed 2%CPU (0avgtext+0avgdata 20480maxresident)k
+38inputs+0outputs (0major+5158minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145734.2
+0.23user 0.68system 0:38.25elapsed 2%CPU (0avgtext+0avgdata 21504maxresident)k
+0inputs+0outputs (0major+5159minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145734.3
+0.25user 0.72system 0:39.50elapsed 2%CPU (0avgtext+0avgdata 19456maxresident)k
+38inputs+0outputs (0major+5158minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145734.4
+0.24user 0.71system 0:41.65elapsed 2%CPU (0avgtext+0avgdata 20480maxresident)k
+0inputs+0outputs (0major+5158minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4145735.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4145735.out
@@ -1,0 +1,44 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.95user 1.97system 1:45.66elapsed 2%CPU (0avgtext+0avgdata 22528maxresident)k
+2864inputs+0outputs (10major+6437minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145735.1
+0.76user 1.81system 2:26.45elapsed 1%CPU (0avgtext+0avgdata 23552maxresident)k
+38inputs+8outputs (0major+6439minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.82user 1.97system 1:10.16elapsed 3%CPU (0avgtext+0avgdata 22528maxresident)k
+0inputs+0outputs (0major+6440minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.78user 1.86system 1:10.19elapsed 3%CPU (0avgtext+0avgdata 23552maxresident)k
+0inputs+0outputs (0major+6440minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.79user 1.88system 1:11.95elapsed 3%CPU (0avgtext+0avgdata 23552maxresident)k
+0inputs+0outputs (0major+6440minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4145736.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4145736.out
@@ -1,0 +1,43 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.03system 0:21.05elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+2854inputs+0outputs (10major+3213minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.01system 0:11.42elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+38inputs+0outputs (0major+3218minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.01system 0:12.20elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3218minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.00system 0:11.33elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3218minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1 -n 8 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.01system 0:12.25elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3218minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4145737.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4145737.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.01user 0.03system 0:23.13elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+2854inputs+0outputs (10major+3401minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145737.1
+0.01user 0.02system 0:13.33elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+38inputs+0outputs (0major+3407minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145737.2
+0.01user 0.02system 0:11.52elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+38inputs+0outputs (0major+3407minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145737.3
+0.01user 0.02system 0:11.46elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3407minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 8 -n 64 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145737.4
+0.01user 0.02system 0:11.43elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3407minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4145738.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4145738.out
@@ -1,0 +1,46 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.02user 0.08system 0:24.03elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+2854inputs+0outputs (10major+3921minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145738.1
+0.02user 0.06system 0:14.63elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+38inputs+0outputs (0major+3927minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145738.2
+0.01user 0.06system 0:14.36elapsed 0%CPU (0avgtext+0avgdata 18432maxresident)k
+0inputs+0outputs (0major+3926minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145738.3
+0.01user 0.06system 0:14.18elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3927minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 64 -n 512 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.02user 0.06system 0:14.91elapsed 0%CPU (0avgtext+0avgdata 17408maxresident)k
+0inputs+0outputs (0major+3928minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4145739.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4145739.out
@@ -1,0 +1,47 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.31user 0.71system 1:04.19elapsed 1%CPU (0avgtext+0avgdata 19456maxresident)k
+2854inputs+0outputs (10major+5154minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145739.1
+0.23user 0.66system 0:41.63elapsed 2%CPU (0avgtext+0avgdata 19456maxresident)k
+38inputs+0outputs (0major+5157minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145739.2
+0.23user 0.64system 0:41.94elapsed 2%CPU (0avgtext+0avgdata 20480maxresident)k
+0inputs+0outputs (0major+5156minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145739.3
+0.24user 0.65system 0:44.37elapsed 2%CPU (0avgtext+0avgdata 20480maxresident)k
+0inputs+0outputs (0major+5158minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 512 -n 4096 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145739.4
+0.22user 0.65system 0:41.68elapsed 2%CPU (0avgtext+0avgdata 20480maxresident)k
+0inputs+0outputs (0major+5155minor)pagefaults 0swaps
++ set +x

--- a/data/lustre-baseline/python-pytorch/slurm-4145740.out
+++ b/data/lustre-baseline/python-pytorch/slurm-4145740.out
@@ -1,0 +1,48 @@
+
+Lmod is automatically replacing "cce/18.0.1" with "amd/6.2.4".
+
+
+Lmod is automatically replacing "PrgEnv-cray/8.6.0" with "PrgEnv-amd/8.6.0".
+
+
+Due to MODULEPATH changes, the following have been reloaded:
+  1) cray-libsci/24.11.0     2) cray-mpich/8.1.31     3) darshan-runtime/3.4.6-mpi
+
+
+The following have been reloaded with a version change:
+  1) amd/6.2.4 => amd/6.4.2
+  2) cray-dsmml/0.3.0 => cray-dsmml/0.3.1
+  3) cray-libsci/24.11.0 => cray-libsci/25.09.0
+  4) cray-mpich/8.1.31 => cray-mpich/9.0.1
+  5) cray-pmi/6.1.15 => cray-pmi/6.1.16
+  6) craype/2.7.33 => craype/2.7.35
+  7) darshan-runtime/3.4.6-mpi => darshan-runtime/3.4.7-mpi
+  8) perftools-base/24.11.0 => perftools-base/25.09.0
+
+++ seq 1 5
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.92user 1.92system 1:36.21elapsed 2%CPU (0avgtext+0avgdata 25600maxresident)k
+2854inputs+0outputs (10major+6674minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Job 4145740 step creation temporarily disabled, retrying (Requested nodes are busy)
+srun: Step created for StepId=4145740.1
+0.73user 1.82system 3:06.17elapsed 1%CPU (0avgtext+0avgdata 21504maxresident)k
+38inputs+8outputs (0major+6785minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+0.72user 1.82system 1:00.76elapsed 4%CPU (0avgtext+0avgdata 23552maxresident)k
+0inputs+0outputs (0major+7211minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Job 4145740 step creation temporarily disabled, retrying (Requested nodes are busy)
+srun: Step created for StepId=4145740.3
+0.84user 1.85system 3:04.89elapsed 1%CPU (0avgtext+0avgdata 22528maxresident)k
+0inputs+8outputs (0major+7277minor)pagefaults 0swaps
++ for i in $(seq 1 5)
++ /usr/bin/time srun -N 1024 -n 8192 -c 7 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest python3 -c 'import torch'
+srun: Step created for StepId=4145740.4
+0.76user 1.86system 2:56.38elapsed 1%CPU (0avgtext+0avgdata 23552maxresident)k
+0inputs+8outputs (0major+7212minor)pagefaults 0swaps
++ set +x


### PR DESCRIPTION
This branch contains results for all 3 iterations for osu, pytorch and mpi4py workloads for Lustre_orion runs.